### PR TITLE
Proper handling of Redis connection issues

### DIFF
--- a/src/main/java/com/chiwanpark/flume/plugins/AbstractRedisSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/AbstractRedisSink.java
@@ -27,6 +27,9 @@ public abstract class AbstractRedisSink extends AbstractSink implements Configur
       jedis.auth(redisPassword);
     }
 
+    // try to connect here already to find out about problems early on
+    // TODO: we may need to throw a special kind of exception here
+    jedis.connect();
     super.start();
 
     LOG.info("Redis Connected. (host: " + redisHost + ", port: " + String.valueOf(redisPort)

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
@@ -70,6 +70,8 @@ public class RedisListDrivenSink extends AbstractRedisSink {
       // we need to rethrow jedis exceptions, because they signal that something went wrong
       // with the connection to the redis server
       if (e instanceof JedisException) {
+        // TODO: we could try to reconnect and resend immediately
+        jedis.disconnect();
         throw new EventDeliveryException(e);
       }
 

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
@@ -8,6 +8,7 @@ import org.apache.flume.EventDeliveryException;
 import org.apache.flume.Transaction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.jedis.exceptions.JedisException;
 
 public class RedisListDrivenSink extends AbstractRedisSink {
   private static final Logger LOG = LoggerFactory.getLogger(RedisListDrivenSink.class);
@@ -65,6 +66,12 @@ public class RedisListDrivenSink extends AbstractRedisSink {
     } catch (Throwable e) {
       transaction.rollback();
       status = Status.BACKOFF;
+
+      // we need to rethrow jedis exceptions, because they signal that something went wrong
+      // with the connection to the redis server
+      if (e instanceof JedisException) {
+        throw e;
+      }
 
       if (e instanceof Error) {
         throw (Error) e;

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
@@ -70,7 +70,7 @@ public class RedisListDrivenSink extends AbstractRedisSink {
       // we need to rethrow jedis exceptions, because they signal that something went wrong
       // with the connection to the redis server
       if (e instanceof JedisException) {
-        throw e;
+        throw new EventDeliveryException(e);
       }
 
       if (e instanceof Error) {

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
@@ -74,6 +74,8 @@ public class RedisPublishDrivenSink extends AbstractRedisSink implements Configu
       // we need to rethrow jedis exceptions, because they signal that something went wrong
       // with the connection to the redis server
       if (e instanceof JedisException) {
+        // TODO: we could try to reconnect and resend immediately
+        jedis.disconnect();
         throw new EventDeliveryException(e);
       }
 

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
@@ -24,6 +24,7 @@ import org.apache.flume.Transaction;
 import org.apache.flume.conf.Configurable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.jedis.exceptions.JedisException;
 
 public class RedisPublishDrivenSink extends AbstractRedisSink implements Configurable {
   private static final Logger LOG = LoggerFactory.getLogger(RedisPublishDrivenSink.class);
@@ -69,6 +70,12 @@ public class RedisPublishDrivenSink extends AbstractRedisSink implements Configu
     } catch (Throwable e) {
       transaction.rollback();
       status = Status.BACKOFF;
+
+      // we need to rethrow jedis exceptions, because they signal that something went wrong
+      // with the connection to the redis server
+      if (e instanceof JedisException) {
+        throw e;
+      }
 
       if (e instanceof Error) {
         throw (Error) e;

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
@@ -74,7 +74,7 @@ public class RedisPublishDrivenSink extends AbstractRedisSink implements Configu
       // we need to rethrow jedis exceptions, because they signal that something went wrong
       // with the connection to the redis server
       if (e instanceof JedisException) {
-        throw e;
+        throw new EventDeliveryException(e);
       }
 
       if (e instanceof Error) {


### PR DESCRIPTION
When the redis connection breaks in the Redis{List, Publish}DrivenSink, Flume cannot find out about it, because the exception is not propagated up. This is however very useful for usage for example with the FailoverSinkProcessor, which would switch to a backup redis sink in those cases.

This PR fixes the classes so that the failure is reported to Flume (through rethrowing the exception) and also resets the connection, so that upon the next invocation it will automatically try to reconnect.