### PR TITLE
Make RawHandler handle binaries instead of Strings

### DIFF
--- a/src/main/java/com/chiwanpark/flume/plugins/AbstractRedisSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/AbstractRedisSink.java
@@ -7,12 +7,12 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.sink.AbstractSink;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import redis.clients.jedis.Jedis;
+import redis.clients.jedis.BinaryJedis;
 
 public abstract class AbstractRedisSink extends AbstractSink implements Configurable {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractRedisSink.class);
 
-  protected Jedis jedis;
+  protected BinaryJedis jedis;
 
   private String redisHost;
   private int redisPort;
@@ -22,7 +22,7 @@ public abstract class AbstractRedisSink extends AbstractSink implements Configur
 
   @Override
   public synchronized void start() {
-    jedis = new Jedis(redisHost, redisPort, redisTimeout);
+    jedis = new BinaryJedis(redisHost, redisPort, redisTimeout);
     if (!"".equals(redisPassword)) {
       jedis.auth(redisPassword);
     }

--- a/src/main/java/com/chiwanpark/flume/plugins/AbstractRedisSource.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/AbstractRedisSource.java
@@ -8,13 +8,14 @@ import org.apache.flume.conf.Configurable;
 import org.apache.flume.source.AbstractSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import redis.clients.jedis.BinaryJedis;
 import redis.clients.jedis.Jedis;
 import redis.clients.jedis.exceptions.JedisConnectionException;
 
 public class AbstractRedisSource extends AbstractSource implements Configurable {
   private static final Logger LOG = LoggerFactory.getLogger(AbstractRedisSource.class);
 
-  protected Jedis jedis;
+  protected BinaryJedis jedis;
   protected ChannelProcessor channelProcessor;
 
   private String redisHost;

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSink.java
@@ -14,12 +14,12 @@ public class RedisListDrivenSink extends AbstractRedisSink {
   private static final Logger LOG = LoggerFactory.getLogger(RedisListDrivenSink.class);
 
   private int redisDatabase;
-  private String redisList;
+  private byte[] redisList;
 
   @Override
   public void configure(Context context) {
     redisDatabase = context.getInteger("redisDatabase", 0);
-    redisList = context.getString("redisList");
+    redisList = context.getString("redisList").getBytes();
 
     Preconditions.checkNotNull(redisList, "Redis List must be set.");
 
@@ -55,7 +55,7 @@ public class RedisListDrivenSink extends AbstractRedisSink {
       transaction.begin();
 
       Event event = channel.take();
-      String serialized = messageHandler.getString(event);
+      byte[] serialized = messageHandler.getBytes(event);
 
       if (jedis.lpush(redisList, serialized) > 0) {
         transaction.commit();

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSource.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisListDrivenSource.java
@@ -13,12 +13,12 @@ public class RedisListDrivenSource extends AbstractRedisSource implements Pollab
   private static final Logger LOG = LoggerFactory.getLogger(RedisListDrivenSource.class);
 
   private int redisDatabase;
-  private String redisList;
+  private byte[] redisList;
 
   @Override
   public void configure(Context context) {
     redisDatabase = context.getInteger("redisDatabase", 0);
-    redisList = context.getString("redisList");
+    redisList = context.getString("redisList").getBytes();
     Preconditions.checkNotNull(redisList, "Redis List must be set.");
 
     super.configure(context);
@@ -38,7 +38,7 @@ public class RedisListDrivenSource extends AbstractRedisSource implements Pollab
 
   @Override
   public Status process() throws EventDeliveryException {
-    String serialized = jedis.rpop(redisList);
+    byte[] serialized = jedis.rpop(redisList);
     if (serialized == null) {
       return Status.BACKOFF;
     }

--- a/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/RedisPublishDrivenSink.java
@@ -29,11 +29,11 @@ import redis.clients.jedis.exceptions.JedisException;
 public class RedisPublishDrivenSink extends AbstractRedisSink implements Configurable {
   private static final Logger LOG = LoggerFactory.getLogger(RedisPublishDrivenSink.class);
 
-  private String redisChannel;
+  private byte[] redisChannel;
 
   @Override
   public void configure(Context context) {
-    redisChannel = context.getString("redisChannel");
+    redisChannel = context.getString("redisChannel").getBytes();
 
     Preconditions.checkNotNull(redisChannel, "Redis Channel must be set.");
 
@@ -58,7 +58,7 @@ public class RedisPublishDrivenSink extends AbstractRedisSink implements Configu
       transaction.begin();
 
       Event event = channel.take();
-      String serialized = messageHandler.getString(event);
+      byte[] serialized = messageHandler.getBytes(event);
 
       if (jedis.publish(redisChannel, serialized) > 0) {
         transaction.commit();

--- a/src/main/java/com/chiwanpark/flume/plugins/handler/JSONHandler.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/handler/JSONHandler.java
@@ -87,12 +87,12 @@ public class JSONHandler extends RedisMessageHandler {
    * {@inheritDoc}
    */
   @Override
-  public Event getEvent(String message) throws Exception {
+  public Event getEvent(byte[] message) throws Exception {
     /*
      * Gson throws Exception if the data is not parseable to JSON.
      * Need not catch it since the source will catch it and return error.
      */
-    JsonObject json = parser.parse(message).getAsJsonObject();
+    JsonObject json = parser.parse(new String(message, this.charset)).getAsJsonObject();
 
     String body = "";
     JsonElement bodyElm = json.get("body");
@@ -118,7 +118,7 @@ public class JSONHandler extends RedisMessageHandler {
   }
 
   @Override
-  public String getString(Event event) throws Exception {
+  public byte[] getBytes(Event event) throws Exception {
     JsonPrimitive body = new JsonPrimitive(new String(event.getBody(), charset));
     JsonObject obj = new JsonObject();
 
@@ -131,6 +131,6 @@ public class JSONHandler extends RedisMessageHandler {
       obj.add("headers", headers);
     }
 
-    return gson.toJson(obj);
+    return gson.toJson(obj).getBytes(charset);
   }
 }

--- a/src/main/java/com/chiwanpark/flume/plugins/handler/RawHandler.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/handler/RawHandler.java
@@ -35,15 +35,15 @@ public class RawHandler extends RedisMessageHandler {
    * {@inheritDoc}
    */
   @Override
-  public Event getEvent(String message) throws Exception {
-    return EventBuilder.withBody(message.getBytes(charset));
+  public Event getEvent(byte[] message) throws Exception {
+    return EventBuilder.withBody(message);
   }
 
   /**
    * {@inheritDoc}
    */
   @Override
-  public String getString(Event event) throws Exception {
-    return new String(event.getBody(), charset);
+  public byte[] getBytes(Event event) throws Exception {
+    return event.getBody();
   }
 }

--- a/src/main/java/com/chiwanpark/flume/plugins/handler/RedisMessageHandler.java
+++ b/src/main/java/com/chiwanpark/flume/plugins/handler/RedisMessageHandler.java
@@ -43,7 +43,7 @@ public abstract class RedisMessageHandler {
    * @return Flume event generated from the request.
    * @throws Exception If there was an unexpected error.
    */
-  public abstract Event getEvent(String message) throws Exception;
+  public abstract Event getEvent(byte[] message) throws Exception;
 
   /**
    * Takes a event and returns a string representing the event. The result
@@ -54,5 +54,5 @@ public abstract class RedisMessageHandler {
    * @return String representing the given event.
    * @throws Exception If there was an unexpected error.
    */
-  public abstract String getString(Event event) throws Exception;
+  public abstract byte[] getBytes(Event event) throws Exception;
 }

--- a/src/test/java/com/chiwanpark/flume/plugins/RedisSourceTestBase.java
+++ b/src/test/java/com/chiwanpark/flume/plugins/RedisSourceTestBase.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 import redis.clients.jedis.Jedis;
 
 @RunWith(JUnit4.class)
-public class RedisSourceTestBase {
+public abstract class RedisSourceTestBase {
   private static final Logger LOG = LoggerFactory.getLogger(RedisSourceTestBase.class);
 
   protected Context context = new Context();

--- a/src/test/java/com/chiwanpark/flume/plugins/handler/JSONHandlerTest.java
+++ b/src/test/java/com/chiwanpark/flume/plugins/handler/JSONHandlerTest.java
@@ -33,7 +33,7 @@ import static org.junit.Assert.assertEquals;
 public class JSONHandlerTest {
   @Test
   public void testJson() throws Exception {
-    String jsonified = "{\"body\": \"hello\"}";
+    byte[] jsonified = "{\"body\": \"hello\"}".getBytes("UTF-8");
     JSONHandler handler = new JSONHandler("utf-8");
 
     Event event = handler.getEvent(jsonified);
@@ -47,7 +47,7 @@ public class JSONHandlerTest {
 
   @Test
   public void testJsonWithHeadersAndBody() throws Exception {
-    String jsonified = "{\"body\": \"hello\", \"headers\": {\"a\": \"123\", \"b\": \"hello\"}}";
+    byte[] jsonified = "{\"body\": \"hello\", \"headers\": {\"a\": \"123\", \"b\": \"hello\"}}".getBytes("utf-8");
     JSONHandler handler = new JSONHandler("utf-8");
 
     Event event = handler.getEvent(jsonified);
@@ -59,7 +59,7 @@ public class JSONHandlerTest {
 
   @Test
   public void testJsonWithoutEncoding() throws Exception {
-    String jsonified = "{\"body\": \"한글\"}";
+    byte[] jsonified = "{\"body\": \"한글\"}".getBytes("utf-8");
     JSONHandler handler = new JSONHandler();
 
     Event event = handler.getEvent(jsonified);
@@ -71,12 +71,12 @@ public class JSONHandlerTest {
   public void testJsonSerialization() throws Exception {
     final String message = "hello";
     final String charset = "utf-8";
-    final String expected = "{\"body\":\"hello\"}";
+    final byte[] expected = "{\"body\":\"hello\"}".getBytes(charset);
     JSONHandler handler = new JSONHandler(charset);
     Event event = EventBuilder.withBody(message, Charset.forName(charset));
 
-    String jsonified = handler.getString(event);
-    assertEquals(expected, jsonified);
+    byte[] jsonified = handler.getBytes(event);
+    assertArrayEquals(expected, jsonified);
   }
 
   @Test
@@ -86,23 +86,23 @@ public class JSONHandlerTest {
     headers.put("hello", "goodbye");
 
     final String charset = "utf-8";
-    final String expected = "{\"body\":\"hello\",\"headers\":{\"hello\":\"goodbye\"}}";
+    final byte[] expected = "{\"body\":\"hello\",\"headers\":{\"hello\":\"goodbye\"}}".getBytes(charset);
     JSONHandler handler = new JSONHandler(charset);
     Event event = EventBuilder.withBody(message, Charset.forName(charset), headers);
 
-    String jsonified = handler.getString(event);
-    assertEquals(expected, jsonified);
+    byte[] jsonified = handler.getBytes(event);
+    assertArrayEquals(expected, jsonified);
   }
 
   @Test
   public void testJsonSerde() throws Exception {
-    final String expected = "{\"body\":\"hello\",\"headers\":{\"hello\":\"goodbye\"}}";
     final String charset = "utf-8";
+    final byte[] expected = "{\"body\":\"hello\",\"headers\":{\"hello\":\"goodbye\"}}".getBytes(charset);
 
     JSONHandler handler = new JSONHandler(charset);
     Event event = handler.getEvent(expected);
-    String result = handler.getString(event);
+    byte[] result = handler.getBytes(event);
 
-    assertEquals(result, expected);
+    assertArrayEquals(result, expected);
   }
 }

--- a/src/test/java/com/chiwanpark/flume/plugins/handler/RawHandlerTest.java
+++ b/src/test/java/com/chiwanpark/flume/plugins/handler/RawHandlerTest.java
@@ -21,31 +21,29 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-import java.nio.charset.Charset;
-
 import static org.junit.Assert.assertArrayEquals;
-import static org.junit.Assert.assertEquals;
 
 @RunWith(JUnit4.class)
 public class RawHandlerTest {
 
   @Test
   public void testRawMessageWithUTF8() throws Exception {
-    final String testMessage = "test-UTF8, 한글";
-    RawHandler handler = new RawHandler("utf-8");
+    final String charset = "UTF-8";
+    final byte[] testMessage = "test-UTF8, 한글".getBytes();
+    RawHandler handler = new RawHandler(charset);
     Event event = handler.getEvent(testMessage);
 
-    assertArrayEquals(testMessage.getBytes("utf-8"), event.getBody());
+    assertArrayEquals(testMessage, event.getBody());
   }
 
   @Test
   public void testSerializationWithUTF8() throws Exception {
-    final String charset = "utf-8";
-    final String testMessage = "test-UTF8, 한글";
+    final String charset = "UTF-8";
+    final byte[] testMessage = "test-UTF8, 한글".getBytes();
     RawHandler handler = new RawHandler(charset);
-    Event event = EventBuilder.withBody(testMessage, Charset.forName(charset));
+    Event event = EventBuilder.withBody(testMessage);
 
-    String result = handler.getString(event);
-    assertEquals(testMessage, result);
+    byte[] result = handler.getBytes(event);
+    assertArrayEquals(testMessage, result);
   }
 }


### PR DESCRIPTION
Before this commit, `RawHandler` was handling incoming/outgoing binaries
as UTF-8 Strings. This breaks binary messages which are indeed binary
(e.g. Thrift binaries).

This commit makes the `RawHandler` handle incoming/outgoing binaries
as raw binaries. Note that this change still allows to pass along UTF-8
encoded messages without any changes.